### PR TITLE
Add ability to turn off logging during local development

### DIFF
--- a/packages/vistorian-dynamicego/static/traces/trace.js
+++ b/packages/vistorian-dynamicego/static/traces/trace.js
@@ -129,7 +129,10 @@
     }
 
     function traceEvent(cat, action, label, value) {
-		
+		if (localStorage.getItem('disableLogging') == 'true'){
+			return;
+		}
+
 	//	if (Boolean(localStorage.getItem(LoggingPhase))){
 			if (starting) {
 			//if (StartedLogging()) {

--- a/packages/vistorian-map/static/trace.js
+++ b/packages/vistorian-map/static/trace.js
@@ -129,7 +129,10 @@
     }
 
     function traceEvent(cat, action, label, value) {
-		
+		if (localStorage.getItem('disableLogging') == 'true'){
+			return;
+		}
+
 	//	if (Boolean(localStorage.getItem(LoggingPhase))){
 			if (starting) {
 			//if (StartedLogging()) {

--- a/packages/vistorian-matrix/static/traces/trace.js
+++ b/packages/vistorian-matrix/static/traces/trace.js
@@ -129,7 +129,10 @@
     }
 
     function traceEvent(cat, action, label, value) {
-		
+		if (localStorage.getItem('disableLogging') == 'true'){
+			return;
+		}
+
 	//	if (Boolean(localStorage.getItem(LoggingPhase))){
 			if (starting) {
 			//if (StartedLogging()) {

--- a/packages/vistorian-nodelink/static/trace.js
+++ b/packages/vistorian-nodelink/static/trace.js
@@ -129,7 +129,10 @@
     }
 
     function traceEvent(cat, action, label, value) {
-		
+		if (localStorage.getItem('disableLogging') == 'true'){
+			return;
+		}
+
 	//	if (Boolean(localStorage.getItem(LoggingPhase))){
 			if (starting) {
 			//if (StartedLogging()) {

--- a/packages/vistorian-web/static/traces/trace.js
+++ b/packages/vistorian-web/static/traces/trace.js
@@ -129,7 +129,10 @@
     }
 
     function traceEvent(cat, action, label, value) {
-		
+		if (localStorage.getItem('disableLogging') == 'true'){
+			return;
+		}
+
 	//	if (Boolean(localStorage.getItem(LoggingPhase))){
 			if (starting) {
 			//if (StartedLogging()) {


### PR DESCRIPTION
This avoids the console filling with errors saying that requests to
/trace have failed.

Toggle using:
  localStorage.setItem('disableLogging', 'true')

and:
  localStorage.setItem('disableLogging', 'false')